### PR TITLE
Rename to CONSUL_ADDR

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,7 +10,7 @@ Accepts an object of options described below:
 | ---- | ---- | ------- | ----------- |
 | `prefixes` | `[String]` | `[]` | List of key prefixes to sync |
 | `retryAfter` | `Number` | `5000` | Delay between retries in ms |
-| `uri` | `String` | `process.env.CONSUL_HTTP_ADDR` | Consul base uri |
+| `uri` | `String` | `process.env.CONSUL_ADDR` | Consul base uri |
 
 Returns a `Promise` that rejects with an error if the options are invalid.
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const {
 const schema = Joi.object({
   prefixes:   Joi.array().single().items(Joi.string()).default([]),
   retryAfter: Joi.number().min(0).default(5000),
-  uri:        Joi.string().default(process.env.CONSUL_HTTP_ADDR)
+  uri:        Joi.string().default(process.env.CONSUL_ADDR)
 })
 
 const mellow = compose(curryN(2), backoff(250, 4))

--- a/test/consul.js
+++ b/test/consul.js
@@ -11,7 +11,7 @@ const {
 const { normalizeBy } = require('@articulate/funky')
 
 const kvRegex = /\/v1\/kv\/([^?]+)/
-process.env.CONSUL_HTTP_ADDR = 'http://consul.io'
+process.env.CONSUL_ADDR = 'http://consul.io'
 
 const emitter = new Emitter()
 
@@ -36,7 +36,7 @@ const getKey = curry((recurse, key) => {
 })
 
 const mockConsul = () =>
-  nock(process.env.CONSUL_HTTP_ADDR)
+  nock(process.env.CONSUL_ADDR)
     .replyContentLength()
     .get(kvRegex)
     .query(true)


### PR DESCRIPTION
![not sure I ever learned his real name](https://i.imgur.com/EavtEV6.gif)

Because of the two hardest problems in coding, cache-busting runs a far distant second to naming things.