### PR TITLE
Cleanly handle 404 responses

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,14 +16,14 @@ Returns a `Promise` that rejects with an error if the options are invalid.
 
 Will begin synchronizing your `process.env` with [KV pairs](https://www.consul.io/api/kv.html) stored in [Consul](https://www.consul.io/).  It long-polls for changes, and when notified it will query and merge all of the env vars stored under the given `prefixes` before assigning them onto the `process.env`.
 
-The merge order for env vars is RTL, such that, in the example below, app-specific vars stored under the prefix `apps/my-app/env_vars` will override global vars stored under the prefix `global/env_vars`.
+The merge order for env vars is RTL, such that, in the example below, app-specific vars stored under the prefix `services/my-app/env_vars` will override global vars stored under the prefix `global/env_vars`.
 
 ```js
 if (process.env.NODE_ENV === 'production') {
   require('@articulate/consul-sync')({
     prefixes: [
       `global/env_vars`,
-      `apps/my-app/env_vars`
+      `services/my-app/env_vars`
     ],
     uri: `https://${process.env.CONSUL_ADDR}`
   })

--- a/test/consul.js
+++ b/test/consul.js
@@ -29,11 +29,13 @@ let waiting = {}
 const getKey = curry((recurse, key) => {
   if (!key) return [ 500, {} ]
   const body = recurse === 'true' ? recurseKeys(key) : [ KV[key] ]
-  return [ 200, body, {
-    'content-type': 'application/json',
-    'x-consul-index': reduce(max, 0, pluck('ModifyIndex', body)).toString()
-  } ]
+  return body.length
+    ? [ 200, body, lastIndex(body) ]
+    : [ 404, { message: 'Not found' }, {} ]
 })
+
+const lastIndex = body =>
+  ({ 'x-consul-index': reduce(max, 0, pluck('ModifyIndex', body)).toString() })
 
 const mockConsul = () =>
   nock(uri)

--- a/test/kv.json
+++ b/test/kv.json
@@ -12,11 +12,11 @@
     "Value": "ZDJkZDVkZQ=="
   },
   {
-    "Key": "apps/my-app/env_vars/",
+    "Key": "services/my-app/env_vars/",
     "Value": null
   },
   {
-    "Key": "apps/my-app/env_vars/COLOR",
+    "Key": "services/my-app/env_vars/COLOR",
     "Value": "cmVk"
   }
 ]

--- a/test/sync.js
+++ b/test/sync.js
@@ -10,7 +10,8 @@ describe('consul-sync', () => {
     require('..')({
       prefixes: [
         'globals/env_vars',
-        'apps/my-app/env_vars'
+        'products/not-found',
+        'services/my-app/env_vars'
       ],
       retryAfter: 16,
       uri: consul.uri
@@ -41,7 +42,7 @@ describe('consul-sync', () => {
 
   describe('when a key is updated in Consul', () => {
     beforeEach(done => {
-      consul.update('apps/my-app/env_vars/COLOR', 'green')
+      consul.update('services/my-app/env_vars/COLOR', 'green')
       setTimeout(done, 250)
     })
 


### PR DESCRIPTION
![just a good dilbert](https://i.pinimg.com/originals/4a/53/3f/4a533f8771d12cb77bd7137c87d0cf9f.jpg)

This is in effort to avoid errors like this:
```
{
  "data": {
    "req": {
      "data": {
        "consistent": true,
        "recurse": true
      },
      "headers": {
        "content-type": "application/json"
      },
      "method": "GET",
      "url": "http://consul.priv:8500/v1/kv/services/my-app/env_vars"
    },
    "res": {
      "headers": {
        "x-consul-index": "12795949",
        "x-consul-knownleader": "true",
        "x-consul-lastcontact": "0",
        "date": "Wed, 15 Nov 2017 14:11:44 GMT",
        "content-length": "0",
        "content-type": "text/plain; charset=utf-8",
        "connection": "close"
      },
      "statusCode": 404,
      "statusMessage": "Not Found",
      "body": ""
    }
  },
  "message": "Not Found",
  "name": "Error",
  "output": {
    "statusCode": 404,
    "payload": {
      "statusCode": 404,
      "error": "Not Found",
      "message": "Not Found"
    },
    "headers": {}
  },
  "stack": "Error: Not Found\n    at wrapError (/service/node_modules/@articulate/gimme/lib/wrapError.js:5:15)\n    at <anonymous>\n    at process._tickDomainCallback (internal/process/next_tick.js:228:7)"
}
```
It's expected that :consul: will return 404's for key paths that don't exist, and we should just treat those cases as an empty list of env vars.