### PR TITLE
Handle consul-sync index going backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ Syncs [Consul](https://www.consul.io/) KV pairs to your `process.env`.
 Helps make instant updates to your env vars in memory.
 
 See the [documentation](https://github.com/articulate/consul-sync/blob/master/API.md) for details and examples.
+
+## Using the package locally (rise-com-gateway)
+
+1.  Clone the consul-sync package locally
+1.  Add `- '../consul-sync:/service/node_modules/@articulate/consul-sync'` to `rise-com-gateway/docker-compose.override.yml`
+1.  Run rise-com-gateway as you normally do and it will point to your local copy of `consul-sync`

--- a/README.md
+++ b/README.md
@@ -9,9 +9,3 @@ Syncs [Consul](https://www.consul.io/) KV pairs to your `process.env`.
 Helps make instant updates to your env vars in memory.
 
 See the [documentation](https://github.com/articulate/consul-sync/blob/master/API.md) for details and examples.
-
-## Using the package locally (rise-com-gateway)
-
-1.  Clone the consul-sync package locally
-1.  Add `- '../consul-sync:/service/node_modules/@articulate/consul-sync'` to `rise-com-gateway/docker-compose.override.yml`
-1.  Run rise-com-gateway as you normally do and it will point to your local copy of `consul-sync`

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const Joi          = require('joi')
 const { backoff, mapP, reject, validate } = require('@articulate/funky')
 
 const {
-  always, apply, assoc, compose, composeP, curry, curryN, equals, flip, ifElse, gt,
-  mergeAll, map, pair, partial, path, pathEq, pick, pipe, prop, reduce, unless, when, tap,
+  always, apply, assoc, compose, composeP, curry, curryN, equals, flip, gt, ifElse,
+  mergeAll, map, pair, partial, path, pathEq, pick, pipe, prop, reduce, tap, unless, when,
 } = require('ramda')
 
 const fiveMin = 300 * 1000

--- a/index.js
+++ b/index.js
@@ -6,11 +6,12 @@ const Joi          = require('joi')
 const { backoff, mapP, reject, validate } = require('@articulate/funky')
 
 const {
-  always, assoc, compose, composeP, curry, curryN, equals, flip, ifElse,
-  mergeAll, map, partial, path, pathEq, pick, pipe, prop, reduce, unless
+  always, apply, assoc, compose, composeP, curry, curryN, equals, flip, ifElse, gt,
+  mergeAll, map, pair, partial, path, pathEq, pick, pipe, prop, reduce, unless, when, tap,
 } = require('ramda')
 
 const fiveMin = 300 * 1000
+const INDEX_BEHIND_MESSAGE = 'Previous index greater then new, resetting back to 0!'
 
 const schema = Joi.object({
   prefixes:   Joi.array().single().items(Joi.string()).default([]),
@@ -45,6 +46,11 @@ const logError = pipe(
   console.error
 )
 
+const logInfo = pipe(
+  JSON.stringify,
+  console.log
+)
+
 const notFound = flip(ifElse(pathEq(['output', 'statusCode'], 404)))(reject)
 
 const parseEnv = (env, { Key, Value }) =>
@@ -74,6 +80,21 @@ const sync = curry((opts, index) =>
     .then(always(index))
 )
 
+const isGreaterThan = curry(
+  compose(
+    tap(greaterThen =>
+      greaterThen &&
+        logInfo({
+          message: INDEX_BEHIND_MESSAGE,
+          package: 'consul-sync',
+        })
+    ),
+    apply(gt),
+    map(parseInt),
+    pair
+  )
+)
+
 const url = (uri, prefix) =>
   `${uri}/v1/kv/${prefix}`
 
@@ -81,8 +102,10 @@ const wait = mellow(({ index, uri }, prefix) =>
   gimme({
     data: { consistent: true, index, recurse: true },
     url: url(uri, prefix)
-  }).then(path(['headers', 'x-consul-index']))
-    .catch(notFound(partial(sleep, [ fiveMin, index ])))
+  })
+    .then(path(['headers', 'x-consul-index']))
+    .then(when(isGreaterThan(index), always(0)))
+    .catch(notFound(partial(sleep, [fiveMin, index])))
 )
 
 module.exports = composeP(start, validate(schema))

--- a/index.js
+++ b/index.js
@@ -80,18 +80,18 @@ const sync = curry((opts, index) =>
     .then(always(index))
 )
 
-const isGreaterThan = curry(
-  compose(
+const resetDecreasedIndex = curry(
+  pipe(
+    pair,
+    map(parseInt),
+    apply(gt),
     tap(greaterThen =>
       greaterThen &&
         logInfo({
           message: INDEX_BEHIND_MESSAGE,
           package: 'consul-sync',
         })
-    ),
-    apply(gt),
-    map(parseInt),
-    pair
+    )
   )
 )
 
@@ -104,7 +104,7 @@ const wait = mellow(({ index, uri }, prefix) =>
     url: url(uri, prefix)
   })
     .then(path(['headers', 'x-consul-index']))
-    .then(when(isGreaterThan(index), always(0)))
+    .then(when(resetDecreasedIndex(index), always(0)))
     .catch(notFound(partial(sleep, [fiveMin, index])))
 )
 


### PR DESCRIPTION
### What is this and why does it exist?

-  We've had several occurrences recently where pods did not have the latest values from consul. `consul-sync` uses long polling to listen for changes in consul. When an update is made the index it returned and is almost always higher than the last index and in those cases we update the `process.env` variables and things are in sync. Based on the [documentation](https://www.consul.io/api-docs/features/blocking#implementation-details) there is a scenario where the index may go backwards and in this case we want to reset the index back to `0`. We are not sure if this will fix the issue were seeing but this is a good first step to address this issue. Logging is added to track if this is actually happening.

> **Reset the index if it goes backwards**. While indexes in general are monotonically increasing(i.e. they should only ever increase as time passes), there are several real-world scenarios in which they can go backwards for a given query. Implementations must check to see if a returned index is lower than the previous value, and if it is, should reset index to 0 - effectively restarting their blocking loop. Failure to do so may cause the client to miss future updates for an unbounded time, or to use an invalid index value that causes no blocking and increases load on the servers. Cases where this can occur include: