### PR TITLE
support single prefix sync or a namespaced sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/consul-sync",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Consul helper to sync KV to env vars",
   "main": "index.js",
   "repository": "git@github.com:articulate/consul-sync.git",

--- a/test/sync.js
+++ b/test/sync.js
@@ -11,11 +11,11 @@ describe('consul-sync', () => {
     chai.spy.on(console, 'info')
 
     require('..')({
-      prefixes: [
-        'globals/env_vars',
-        'products/not-found',
-        'services/my-app/env_vars'
-      ],
+      prefixes: {
+        '': 'globals/env_vars',
+        products: 'products/not-found',
+        'my-app': 'services/my-app/env_vars',
+      },
       uri: consul.uri
     })
 
@@ -27,7 +27,8 @@ describe('consul-sync', () => {
   )
 
   it('syncs the Consul KV store to the process.env', () => {
-    expect(process.env.COLOR).to.equal('red')
+    expect(process.env.COLOR).to.equal('blue')
+    expect(process.env.MY_APP_COLOR).to.equal('red')
     expect(process.env.SHA).to.equal('d2dd5de')
   })
 
@@ -49,7 +50,7 @@ describe('consul-sync', () => {
     })
 
     it('updates the process.env', () =>
-      expect(process.env.COLOR).to.equal('green')
+      expect(process.env.MY_APP_COLOR).to.equal('green')
     )
   })
 


### PR DESCRIPTION
this will add support for namespacing env vars when pulling from multiple consul keys